### PR TITLE
Silence warning on Z3 hash check

### DIFF
--- a/src/smtencoding/FStar.SMTEncoding.Z3.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fs
@@ -108,7 +108,7 @@ let check_z3hash () =
     end
 
 let ini_params () =
-  check_z3hash ();
+(*  check_z3hash ();        Silence hash check until we need it *)
   (String.concat " "
                 (List.append
                  [ "-smt2 -in auto_config=false model=true smt.relevancy=2";


### PR DESCRIPTION
Our modified Z3 raises warnings whenever it runs due to having a different hash. This scraps the warning.